### PR TITLE
add:pydanticによるデータクラスを追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest==7.4.3
+pydantic==2.5.2

--- a/src/models/data_model.py
+++ b/src/models/data_model.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+
+class Employee(BaseModel):
+    employee_id: int
+    name: str
+    created_at: datetime
+
+
+class Contract(BaseModel):
+    contract_id: int
+    image_link: str
+    contractor: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class EmployeeEvent(BaseModel):
+    contract_id: int
+    employee_id: int
+    created_at: datetime
+    updated_at: datetime
+    event_type: str

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -1,0 +1,58 @@
+from models.data_model import Employee, Contract, EmployeeEvent
+from datetime import datetime
+
+
+def test_employee():
+    employee_data = {
+        "employee_id": 11111,
+        "name": "山田太郎",
+        "created_at": "2099-01-01 01:00:00",
+    }
+
+    actual = Employee(**employee_data).model_dump()
+    expected = {
+        "employee_id": 11111,
+        "name": "山田太郎",
+        "created_at": datetime(2099, 1, 1, 1, 0),
+    }
+    assert actual == expected
+
+
+def test_contract():
+    contract_data = {
+        "contract_id": 11111,
+        "image_link": "サンプルリンク",
+        "contractor": "サンプル株式会社",
+        "created_at": "2099-01-01 01:00:00",
+        "updated_at": "2099-01-01 01:00:00",
+    }
+
+    actual = Contract(**contract_data).model_dump()
+    expected = {
+        "contract_id": 11111,
+        "image_link": "サンプルリンク",
+        "contractor": "サンプル株式会社",
+        "created_at": datetime(2099, 1, 1, 1, 0),
+        "updated_at": datetime(2099, 1, 1, 1, 0),
+    }
+    assert actual == expected
+
+
+def test_employee_event():
+    event_data = {
+        "contract_id": 11111,
+        "employee_id": 22222,
+        "created_at": "2099-01-01 01:00:00",
+        "updated_at": "2099-01-01 01:00:00",
+        "event_type": "CREATED",
+    }
+
+    actual = EmployeeEvent(**event_data).model_dump()
+    expected = {
+        "contract_id": 11111,
+        "employee_id": 22222,
+        "created_at": datetime(2099, 1, 1, 1, 0),
+        "updated_at": datetime(2099, 1, 1, 1, 0),
+        "event_type": "CREATED",
+    }
+    assert actual == expected


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- データの型を指定し、バリデーションエラーを検知する仕組みを構築することで、コードの品質を担保する
  - pydanticライブラリを使用する


# チケット・参考リンク
- https://qiita.com/0622okakyo/items/d1dcb896621907f9002b

# 変更内容
- pydanticライブラリを使って、型を定義する
  - 社員データ
  - 契約書データ
  - 契約書アップロードアクションのデータ
- テストコードの追加

# 動作確認（確認方法とプロセスを明確に記載する）
- pytestの実行による確認
  - `$pytest tests/test_data_model.py`

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
