### PR TITLE
add:OpenAIによる契約書の項目抽出メソッドを実装する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv/
 .env
 key.json
+__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pydantic==2.5.2
 google-cloud-vision==3.4.5
 pdf2image==1.16.3
 streamlit==1.29.0
+openai==1.3.8
+python-dotenv==1.0.0

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1,18 +1,32 @@
 from pathlib import Path
 from typing import Union
 from PIL import Image
+import os
+from dotenv import load_dotenv
 
 from google.cloud import vision
 from google.oauth2 import service_account
+from openai import OpenAI
 
 from backend.ocr import google_vision
 from streamlit.runtime.uploaded_file_manager import UploadedFile
+from backend.modules.extract_items import OpenaiItemExtractor
+
+load_dotenv(verbose=True)
 
 CREDENTIAL = service_account.Credentials.from_service_account_file("../key.json")
-CLIENT = vision.ImageAnnotatorClient(credentials=CREDENTIAL)
+GOOGLECLIENT = vision.ImageAnnotatorClient(credentials=CREDENTIAL)
+
+os.environ["OPENAI_API_KEY"] = os.environ.get("OPENAI_API_KEY")
+OPENAI_CLIENT = OpenAI()
 
 
 def detect(jpeg_file: Union[UploadedFile, Image.Image]) -> str:
-    google_vision_detecter = google_vision.GoogleVisionDetecter(CLIENT)
+    google_vision_detecter = google_vision.GoogleVisionDetecter(GOOGLECLIENT)
     response = google_vision_detecter.detect_text(jpeg_file)
     return response
+
+
+def extract_items(text: str) -> dict[str, dict[str, any]]:
+    openai_item_extractor = OpenaiItemExtractor(OPENAI_CLIENT)
+    return openai_item_extractor.extract_items(text)

--- a/src/backend/models/item_extractor.py
+++ b/src/backend/models/item_extractor.py
@@ -1,0 +1,25 @@
+from abc import abstractmethod, ABC
+from openai import OpenAI
+
+
+class ItemExtractor(ABC):
+    def __init__(self, openai_client: OpenAI) -> None:
+        self.client = openai_client
+
+    @abstractmethod
+    def extract_items(self) -> dict[str, dict[str, any]]:
+        """OCRテキストから、特定の情報を辞書形式で書き出す
+        args:
+            image_path str: 読み込み対象となる画像が存在しているパス
+        return:
+            dict[str, dict[str, str]]: 契約書内の項目とその項目の内容
+            ex:
+                {
+                    "content": {
+                        "物件名": "物件A",
+                        "賃料": 100,
+                        "契約日": "2023年1月1日",
+                    }
+                }
+        """
+        raise NotImplementedError()

--- a/src/backend/modules/extract_items.py
+++ b/src/backend/modules/extract_items.py
@@ -1,0 +1,46 @@
+import json
+
+from openai import OpenAI
+
+from backend.models.item_extractor import ItemExtractor
+
+
+class OpenaiItemExtractor(ItemExtractor):
+    def __init__(self, openai_client: OpenAI) -> None:
+        self.client = openai_client
+
+    def extract_items(self, text) -> dict[str, dict[str, any]]:
+        system_prompt = """
+        あなたは契約書から項目を読み取るアシスタントです。
+        与えられた文字列に対して、物件名と住所をJSON形式でパースしてください。
+        JSONのキーはname, locationとしてください。
+
+        nameは物件名で、文字列オブジェクトです。
+        locationは住所で、文字列オブジェクトです。
+
+        抽出できなかった項目に関しては、空のバリューを返してください。
+        """
+
+        prompt = f"""
+        次の入力を、所定のJSONフォーマットで出力してください。
+        - [入力]
+        {text}
+
+        - [出力JSONフォーマット]
+        {{
+            "content":{{
+                "物件名": *(str型)
+                "住所": *(str型)
+            }},
+        }}
+        """
+        response = self.client.chat.completions.create(
+            model="gpt-3.5-turbo-1106",
+            temperature=0.2,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        return json.loads(response.choices[0].message.content)

--- a/src/frontend/pages/index.py
+++ b/src/frontend/pages/index.py
@@ -8,7 +8,7 @@ sys.path.append(str(pathlib.Path().absolute()))
 from backend.modules.pdf_to_image import (
     convert_streamlit_pdf_to_images,
 )
-from backend.main import detect
+from backend.main import detect, extract_items
 
 
 def index_page() -> None:
@@ -25,7 +25,19 @@ def index_page() -> None:
         st.image(file)
 
         response = detect(file)
-        st.write(response)
+        # TODO:フロントの責務を分離する
+        contract_items = extract_items(response)
+
+        # JSONオブジェクトの各キーと値を表示し、編集可能にする
+        edited_json = {}
+        for key, value in contract_items["content"].items():
+            new_value = st.sidebar.text_input(f"{key}: ", value)
+            edited_json[key] = new_value
+
+        # 編集された内容を表示するボタン
+        if st.sidebar.button("更新"):
+            st.sidebar.write("更新されたJSON:")
+            st.sidebar.json(edited_json)
 
 
 index_page()

--- a/tests/models/test_item_extractor.py
+++ b/tests/models/test_item_extractor.py
@@ -1,0 +1,16 @@
+from backend.models.item_extractor import ItemExtractor
+
+
+class MyTestClass(ItemExtractor):
+    def __init__(self) -> None:
+        pass
+
+    def extract_items(self, text: str = "テスト") -> dict[str, dict[str, any]]:
+        return {"content": {"物件名": "テスト物件", "賃料": 999, "契約日": "テスト契約日"}}
+
+
+def test_item_extractor():
+    obj = MyTestClass()
+    obj.extract_items("テスト") == {
+        "content": {"物件名": "テスト物件", "賃料": 999, "契約日": "テスト契約日"}
+    }


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
契約書のOCRを行う上で、OCR機能に加えて、契約書の項目を自動抽出する機能をつけたい
- 項目抽出メソッドを実装する
- フロントエンドとの接続も加える

# チケット・参考リンク


# 変更内容
- ライブラリの追加
- 項目抽出メソッドの抽象クラス作成
  - pytestによるテストも実装
- 項目抽出メソッドの具象クラスを作成
  - バックエンドのメインファイルに組み込む
  - メソッドのテストコードも実装
- 項目抽出メソッドを簡易的に、フロントエンドと接続させる
- pythonキャッシュが保存されないようにする

# 動作確認（確認方法とプロセスを明確に記載する）
- 抽象クラスのテストをpytestで確認
  - 抽象クラスを継承した具象クラスを作成できるのか
  - `cd tests && pytest models/test_item_extractor.py`
- streamlitで、項目抽出メソッドが動くのか確認
  - `cd src && pytest streamlit run frontend/pages/index.py`

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
