### PR TITLE
change: フロントエンドの修正・1ファイルずつ処理できるようにする

### DIFF
--- a/src/frontend/component/organisms/file_processor.py
+++ b/src/frontend/component/organisms/file_processor.py
@@ -1,0 +1,24 @@
+from PIL import Image
+from typing import Union
+
+import streamlit as st
+from streamlit.runtime.uploaded_file_manager import UploadedFile
+
+from backend.main import detect, extract_items
+
+
+def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
+    response = detect(jpeg_file)
+    contract_items = extract_items(response)
+
+    # JSONオブジェクトの各キーと値を表示し、編集可能にする
+    edited_json = {}
+    for key, value in contract_items["content"].items():
+        new_value = st.sidebar.text_input(f"{key}: ", value)
+        edited_json[key] = new_value
+
+    if st.sidebar.button("保存"):
+        st.sidebar.write("以下の内容で保存されました🎉")
+        st.sidebar.json(edited_json)
+
+        return edited_json

--- a/src/frontend/component/utils/navigation.py
+++ b/src/frontend/component/utils/navigation.py
@@ -1,0 +1,11 @@
+import streamlit as st
+
+
+def next_file():
+    if st.session_state["current_index"] < len(st.session_state["upload_files"]) - 1:
+        st.session_state["current_index"] += 1
+
+
+def previous_file():
+    if st.session_state["current_index"] > 0:
+        st.session_state["current_index"] -= 1


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- 現状は、アップロードファイル全てを一度に表示している
  - 直感的にどのアップロードファイルを操作しているのかわからず、ユーザ体験が悪い
  - 1ファイルずつ処理して、編集できるように仕様を修正する

# チケット・参考リンク
- フロントエンドの設計は、Atomic Designを参考にリファクタリング
  - https://info.drobe.co.jp/blog/engineering/react-component-atomic-design

# 変更内容
- 各アップロードファイルを移動できるメソッドを実装
- OCRや項目抽出などの、ファイル処理機能を別ファイルに分岐
- streamlitのsession_stateを用いて、1ファイルごとの処理をできるように修正

# 動作確認（確認方法とプロセスを明確に記載する）
- streamlitによる確認
  - `cd src && streamlit run frontend/pages/index.py`

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [ ] プルリクにAssigneesは割り当てられているか
