### PR TITLE
add:アップした契約書一覧を表示する為に、ダッシュボードページを追加する

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ openai==1.3.8
 python-dotenv==1.0.0
 fastapi==0.105.0
 psycopg2==2.9.9
+uvicorn==0.24.0.post1

--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+from pages import index, dashboard
+
+
+def main():
+    page = st.sidebar.selectbox(
+        label="ページを選択してください", options=["トップページ", "アップロード画面", "ダッシュボード"]
+    )
+
+    if page == "アップロード画面":
+        index.index_page()
+    if page == "ダッシュボード":
+        dashboard.dashboard_page()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/frontend/component/api/request.py
+++ b/src/frontend/component/api/request.py
@@ -1,0 +1,8 @@
+import requests
+
+
+def request_read_contract_endpoint(endpoint: str) -> list[dict[str, any]]:
+    response = requests.get(endpoint)
+    if response.status_code == 200:
+        json_data = response.json()
+        return json_data

--- a/src/frontend/pages/dashboard.py
+++ b/src/frontend/pages/dashboard.py
@@ -1,0 +1,12 @@
+import streamlit as st
+import pandas as pd
+from frontend.component.api.request import request_read_contract_endpoint
+
+
+def dashboard_page():
+    print("出力")
+    contracts = request_read_contract_endpoint(
+        endpoint="http://127.0.0.1:8000/get/contracts/"
+    )
+    df = pd.DataFrame(contracts)
+    st.dataframe(df)

--- a/src/frontend/pages/index.py
+++ b/src/frontend/pages/index.py
@@ -13,13 +13,6 @@ from frontend.component.organisms.file_processor import process_file
 from frontend.component.utils.navigation import next_file, previous_file
 
 
-def request():
-    response = requests.get("http://127.0.0.1:8000/get/contracts/")
-    if response.status_code == 200:
-        json_data = response.json()
-        return json_data
-
-
 def index_page() -> None:
     st.title("OCR自動化プロダクト")
     st.sidebar.markdown("### 読み込む契約書をアップロード（複数ファイル可）")


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- アップロードした契約書一覧を表示できるようにしたい
  - ダッシュボードページを作成して、過去の契約書を確認したい

# チケット・参考リンク
- なし

# 変更内容
- fastapiを起動するために、ライブラリ追加
  - python用のasgiサーバーを起動できるようになる
- エンドポイントへのリクエストをフロントディレクトリに実装する
- ダッシュボードページの追加
- メインページから、「ダッシュボード」「契約書アップ画面」を切り替えできるようにする

# 動作確認（確認方法とプロセスを明確に記載する）
- streamlit上の確認
```
uvicorn backend.main:app --reload
streamlit run frontend/app.py
```


# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
