### PR TITLE
change: streamlitのGUI操作で、データをPOSTGRESにinsertできるようにする

### DIFF
--- a/src/backend/crud/insert.py
+++ b/src/backend/crud/insert.py
@@ -4,12 +4,12 @@ from datetime import datetime
 from backend.schemas.schemas import Contract
 
 
-def insert_contract(contract_id: int, contractor: str, db: Session) -> list[Contract]:
+def insert_contract(contractor: str, db: Session) -> list[Contract]:
     current_date = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
     sql = text(
         f"""
-    insert into contract (contract_id, contractor, created_at, updated_at) values \
-    ('{contract_id}', '{contractor}', '{current_date}', '{current_date}')
+    insert into contract (contractor, created_at, updated_at) values \
+    ('{contractor}', '{current_date}', '{current_date}')
     """
     )
     db.execute(sql)

--- a/src/backend/router/insert.py
+++ b/src/backend/router/insert.py
@@ -10,9 +10,8 @@ router = APIRouter()
 
 @router.post("/insert/contracts", response_model=Contract)
 async def insert_contracts_endpoint(
-    contract_id: int,
     contractor: str,
     db: Session = Depends(db.get_db_session),
 ) -> list[Contract]:
-    result = insert.insert_contract(contract_id, contractor, db=db)
+    result = insert.insert_contract(contractor, db=db)
     return result

--- a/src/frontend/component/api/request.py
+++ b/src/frontend/component/api/request.py
@@ -6,3 +6,12 @@ def request_read_contract_endpoint(endpoint: str) -> list[dict[str, any]]:
     if response.status_code == 200:
         json_data = response.json()
         return json_data
+
+
+def request_insert_contract_endpoint(
+    endpoint: str, contractor: str
+) -> list[dict[str, any]]:
+    response = requests.post(f"{endpoint}?contractor={contractor}")
+    if response.status_code == 200:
+        json_data = response.json()
+        return json_data

--- a/src/frontend/component/organisms/file_processor.py
+++ b/src/frontend/component/organisms/file_processor.py
@@ -5,6 +5,7 @@ import streamlit as st
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 from backend.main import detect, extract_items
+from frontend.component.api.request import request_insert_contract_endpoint
 
 
 def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
@@ -20,5 +21,6 @@ def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
     if st.sidebar.button("保存"):
         st.sidebar.write("以下の内容で保存されました🎉")
         st.sidebar.json(edited_json)
-
-        return edited_json
+        request_insert_contract_endpoint(
+            "http://127.0.0.1:8000/insert/contracts", edited_json["物件名"]
+        )

--- a/src/frontend/pages/index.py
+++ b/src/frontend/pages/index.py
@@ -1,6 +1,5 @@
 import pathlib
 import sys
-import requests
 
 import streamlit as st
 
@@ -31,8 +30,8 @@ def index_page() -> None:
             file = convert_streamlit_pdf_to_images(file)
         st.image(file)
 
-        # TODO:このjson情報を、データベースに保存する必要がある
-        edited_json = process_file(file)
+        # OCR推論から項目抽出、データベースへの書き込みまでの責務を持つ
+        process_file(file)
 
         col1, col2 = st.sidebar.columns(2)
         with col1:


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- streamlitのGUIで操作したときに、POSTGRESにデータがinsertされるようにしたい
- contract_idは、indexページで責務を持つ仕様になっているので、自動でID割り振りが行われるようにしたい

# チケット・参考リンク
- https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-serial/

# 変更内容
- contract_idのスキーマをSERIALを指定し、自動的に連続値が書き込まれる仕様に修正する
```
(
    contract_id     SERIAL,
    contractor    VARCHAR(100) NOT NULL,
    created_at     timestamp without time zone      NOT NULL,
    updated_at     timestamp without time zone      NOT NULL,
    PRIMARY KEY (contract_id)
);  
```
- streamlitのindexページで、項目内容を保存するとデータがinsertされるように修正


# 動作確認（確認方法とプロセスを明確に記載する）
- pytestによる確認
  - `cd tests && pytest`
- streamlit上の確認
  - ファイル内容を保存した時に、POSTGRESにデータがinsertされるのか
  - `cd src && streamlit run frontend/app.py`


# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
