### PR TITLE
change: REST APIでエラーハンドリングを追加

### DIFF
--- a/src/backend/crud/insert.py
+++ b/src/backend/crud/insert.py
@@ -1,10 +1,9 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 from datetime import datetime
-from backend.schemas.schemas import Contract
 
 
-def insert_contract(contractor: str, db: Session) -> list[Contract]:
+def insert_contract(contractor: str, db: Session) -> None:
     current_date = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
     sql = text(
         f"""
@@ -14,5 +13,3 @@ def insert_contract(contractor: str, db: Session) -> list[Contract]:
     )
     db.execute(sql)
     db.commit()
-    sql_2 = text("select * from contract order by contract_id desc")
-    return db.execute(sql_2).first()

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -8,6 +8,7 @@ from google.cloud import vision
 from google.oauth2 import service_account
 from openai import OpenAI
 from fastapi import FastAPI
+import uvicorn
 
 from backend.ocr import google_vision
 from streamlit.runtime.uploaded_file_manager import UploadedFile
@@ -40,3 +41,7 @@ def detect(jpeg_file: Union[UploadedFile, Image.Image]) -> str:
 def extract_items(text: str) -> dict[str, dict[str, any]]:
     openai_item_extractor = OpenaiItemExtractor(OPENAI_CLIENT)
     return openai_item_extractor.extract_items(text)
+
+
+if __name__ == "__main__":
+    uvicorn.run("backend.main:app", port=8000, host="0.0.0.0", reload=True)

--- a/src/backend/router/insert.py
+++ b/src/backend/router/insert.py
@@ -17,4 +17,4 @@ async def insert_contracts_endpoint(
         insert.insert_contract(contractor, db=db)
         return {"message": f"insert success: contractor={contractor}"}
     except Exception as e:
-        HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e))

--- a/src/backend/router/insert.py
+++ b/src/backend/router/insert.py
@@ -1,17 +1,20 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+from fastapi import HTTPException
 
 from backend.crud import insert
-from backend.schemas.schemas import Contract
 from backend.db import db
 
 router = APIRouter()
 
 
-@router.post("/insert/contracts", response_model=Contract)
+@router.post("/insert/contracts", response_model=dict[str, str])
 async def insert_contracts_endpoint(
     contractor: str,
     db: Session = Depends(db.get_db_session),
-) -> list[Contract]:
-    result = insert.insert_contract(contractor, db=db)
-    return result
+) -> dict[str, str]:
+    try:
+        insert.insert_contract(contractor, db=db)
+        return {"message": f"insert success: contractor={contractor}"}
+    except Exception as e:
+        HTTPException(status_code=400, detail=str(e))

--- a/src/backend/router/update.py
+++ b/src/backend/router/update.py
@@ -12,7 +12,7 @@ router = APIRouter()
 @router.put("/update/contracts/{contracts_id}", response_model=dict[str, str])
 async def update_contract_endpoint(
     contract_id: int, contractor: str, db: Session = Depends(db.get_db_session)
-):
+) -> dict[str, str]:
     try:
         update.update_contract(contract_id, contractor, db=db)
         return {"message": f"contract_id {contract_id} is updated successfully."}


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- REST APIでエラーハンドリングを実装していない現状
  - エラーが起きた時のデバッグが難しい状況
  - エラーをraiseして、デバッグを容易にする

# チケット・参考リンク
- なし

# 変更内容
- insert文のエラーハンドリングを追加
- update文の返り値を適切にする

# 動作確認（確認方法とプロセスを明確に記載する）
- fastapiのドキュメントページで確認
  - `uvicorn backend.main:app --reload`
  - エラーハンドリングが行われることを確認

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
