### PR TITLE
change:ダッシュボードページで、updateメソッドを呼び出せるようにする

### DIFF
--- a/src/frontend/component/api/request.py
+++ b/src/frontend/component/api/request.py
@@ -1,17 +1,26 @@
 import requests
 
 
-def request_read_contract_endpoint(endpoint: str) -> list[dict[str, any]]:
+def read_contract_endpoint(endpoint: str) -> list[dict[str, any]]:
     response = requests.get(endpoint)
     if response.status_code == 200:
         json_data = response.json()
         return json_data
 
 
-def request_insert_contract_endpoint(
-    endpoint: str, contractor: str
-) -> list[dict[str, any]]:
+def insert_contract_endpoint(endpoint: str, contractor: str) -> list[dict[str, any]]:
     response = requests.post(f"{endpoint}?contractor={contractor}")
     if response.status_code == 200:
-        json_data = response.json()
-        return json_data
+        return response.json()
+
+
+def update_contract_endpoint(
+    contract_id: int,
+    contractor: str,
+    endpoint: str,
+) -> dict[str, str]:
+    response = requests.put(
+        f"{endpoint}{contract_id}?contract_id={contract_id}&contractor={contractor}"
+    )
+    if response.status_code == 200:
+        return response.json()

--- a/src/frontend/component/organisms/file_processor.py
+++ b/src/frontend/component/organisms/file_processor.py
@@ -5,7 +5,7 @@ import streamlit as st
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 from backend.main import detect, extract_items
-from frontend.component.api.request import request_insert_contract_endpoint
+from frontend.component.api.request import insert_contract_endpoint
 
 
 def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
@@ -21,6 +21,6 @@ def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
     if st.sidebar.button("保存"):
         st.sidebar.write("以下の内容で保存されました🎉")
         st.sidebar.json(edited_json)
-        request_insert_contract_endpoint(
+        insert_contract_endpoint(
             "http://127.0.0.1:8000/insert/contracts", edited_json["物件名"]
         )

--- a/src/frontend/component/utils/navigation.py
+++ b/src/frontend/component/utils/navigation.py
@@ -4,8 +4,12 @@ import streamlit as st
 def next_file():
     if st.session_state["current_index"] < len(st.session_state["upload_files"]) - 1:
         st.session_state["current_index"] += 1
+    else:
+        st.error("これより次のファイルはありません")
 
 
 def previous_file():
     if st.session_state["current_index"] > 0:
         st.session_state["current_index"] -= 1
+    else:
+        st.error("これより前のファイルはありません")

--- a/src/frontend/pages/dashboard.py
+++ b/src/frontend/pages/dashboard.py
@@ -1,15 +1,38 @@
 import streamlit as st
 import pandas as pd
-from frontend.component.api.request import request_read_contract_endpoint
+from frontend.component.api.request import (
+    read_contract_endpoint,
+    update_contract_endpoint,
+)
 
 
 def dashboard_page():
     st.title("契約書管理ダッシュボード")
-    contracts = request_read_contract_endpoint(
-        endpoint="http://127.0.0.1:8000/get/contracts/"
-    )
+    contracts = read_contract_endpoint(endpoint="http://127.0.0.1:8000/get/contracts/")
     columns = list(contracts[0].keys())
     sort_column = st.sidebar.selectbox("並び替えるカラムを選択してください", columns)
-    df = pd.DataFrame(contracts).sort_values(by=sort_column)
+    contract_df = pd.DataFrame(contracts).sort_values(by=sort_column)
+    edit_row(contract_df)
+    st.markdown("## 契約書一覧")
+    st.dataframe(contract_df)
 
-    st.dataframe(df)
+
+def edit_row(contract_df: pd.DataFrame) -> dict[str, str]:
+    contract_id = st.selectbox(label="編集するidを選択", options=contract_df["contract_id"])
+    contractor = st.text_input(label="編集内容", value="")
+
+    if st.button("編集保存", key="save_button"):
+        response = update_contract_endpoint(
+            contract_id=contract_id,
+            contractor=contractor,
+            endpoint="http://127.0.0.1:8000/update/contracts/",
+        )
+        contract_df.loc[
+            contract_df["contract_id"] == contract_id, "contractor"
+        ] = contractor
+        st.markdown(
+            f"""
+        修正が成功しました🎉
+        """
+        )
+        return response

--- a/src/frontend/pages/index.py
+++ b/src/frontend/pages/index.py
@@ -14,14 +14,13 @@ from frontend.component.utils.navigation import next_file, previous_file
 
 def index_page() -> None:
     st.title("OCR自動化プロダクト")
-    st.sidebar.markdown("### 読み込む契約書をアップロード（複数ファイル可）")
-    upload_files = st.sidebar.file_uploader(
+    st.markdown("### 読み込む契約書をアップロード（複数ファイル可）")
+    upload_files = st.file_uploader(
         "Upload a PDF or jpeg file", type=["pdf", "jpg"], accept_multiple_files=True
     )
 
     # アップされたファイル情報を一枚ずつ表示するため、indexを状態として保持する
-    if "current_index" not in st.session_state:
-        st.session_state["current_index"] = 0
+    st.session_state["current_index"] = 0
 
     if upload_files:
         st.session_state["upload_files"] = upload_files
@@ -41,6 +40,3 @@ def index_page() -> None:
         with col2:
             if st.button("次へ"):
                 next_file()
-
-
-index_page()


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- ダッシュボードページで、行の内容を修正できるようにしたい
  - リクエストメソッドを作成し、ダッシュボードページUIに反映する

# チケット・参考リンク
- なし

# 変更内容
- ダッシュボードページで、updateメソッドを呼び出せるようにする
- ダッシュボードページUIを修正する

# 動作確認（確認方法とプロセスを明確に記載する）
- streamlitでの確認
- pytestでの確認

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
