### PR TITLE
change:同じ項目内容の入力に対して、エラーハンドリングを行う

### DIFF
--- a/src/backend/crud/get.py
+++ b/src/backend/crud/get.py
@@ -25,5 +25,5 @@ def get_specific_contract(
     )
     result = db.execute(sql).first()
     if result is None:
-        return None  # Return None if no data is found
+        return None
     return Contract(**result._asdict())

--- a/src/backend/crud/get.py
+++ b/src/backend/crud/get.py
@@ -1,6 +1,8 @@
+from typing import Union
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 from fastapi import HTTPException
+
 from backend.schemas.schemas import Contract
 
 
@@ -11,3 +13,17 @@ def get_contracts(db: Session) -> list[Contract]:
         raise HTTPException(status_code=404, detail="Table not found")
     contracts = [Contract(**row._asdict()) for row in result]
     return contracts
+
+
+def get_specific_contract(
+    column_name: str, column_value: str, db: Session
+) -> Union[None, Contract]:
+    sql = text(
+        f"""
+        SELECT * FROM contract WHERE {column_name} = '{column_value}';
+    """
+    )
+    result = db.execute(sql).first()
+    if result is None:
+        return None  # Return None if no data is found
+    return Contract(**result._asdict())

--- a/src/backend/router/get.py
+++ b/src/backend/router/get.py
@@ -1,3 +1,4 @@
+from typing import Union
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -13,4 +14,17 @@ async def get_contracts_endpoint(
     db: Session = Depends(db.get_db_session),
 ) -> list[Contract]:
     contracts = get.get_contracts(db=db)
+    return contracts
+
+
+@router.get("/get/contract", response_model=Union[None, Contract])
+async def get_specific_contract_endpoint(
+    column_name: str,
+    column_value: str,
+    db: Session = Depends(db.get_db_session),
+) -> Contract:
+    contracts = get.get_specific_contract(column_name, column_value, db=db)
+    print("タイプの出力")
+    print(type(contracts))
+    print(contracts)
     return contracts

--- a/src/backend/router/get.py
+++ b/src/backend/router/get.py
@@ -24,7 +24,4 @@ async def get_specific_contract_endpoint(
     db: Session = Depends(db.get_db_session),
 ) -> Contract:
     contracts = get.get_specific_contract(column_name, column_value, db=db)
-    print("タイプの出力")
-    print(type(contracts))
-    print(contracts)
     return contracts

--- a/src/frontend/component/api/request.py
+++ b/src/frontend/component/api/request.py
@@ -16,7 +16,6 @@ def read_specific_contract_endpoint(
     )
     if response.status_code == 200:
         json_data = response.json()
-        print(type(json_data))
         return json_data
 
 

--- a/src/frontend/component/api/request.py
+++ b/src/frontend/component/api/request.py
@@ -8,6 +8,18 @@ def read_contract_endpoint(endpoint: str) -> list[dict[str, any]]:
         return json_data
 
 
+def read_specific_contract_endpoint(
+    endpoint: str, column_name: str, column_value: str
+) -> dict[str, any]:
+    response = requests.get(
+        f"{endpoint}?column_name={column_name}&column_value={column_value}"
+    )
+    if response.status_code == 200:
+        json_data = response.json()
+        print(type(json_data))
+        return json_data
+
+
 def insert_contract_endpoint(endpoint: str, contractor: str) -> list[dict[str, any]]:
     response = requests.post(f"{endpoint}?contractor={contractor}")
     if response.status_code == 200:

--- a/src/frontend/component/organisms/file_processor.py
+++ b/src/frontend/component/organisms/file_processor.py
@@ -6,6 +6,14 @@ from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 from backend.main import detect, extract_items
 from frontend.component.api.request import insert_contract_endpoint
+from frontend.component.api.request import read_specific_contract_endpoint
+
+
+def is_already_exist(column_name: str, value: str) -> bool:
+    response = read_specific_contract_endpoint(
+        "http://127.0.0.1:8000/get/contract", column_name, value
+    )
+    return response is None
 
 
 def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
@@ -20,8 +28,11 @@ def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
         edited_json[key] = new_value
 
     if st.sidebar.button("保存", key="保存ボタン"):
-        st.sidebar.write("以下の内容で保存されました🎉")
-        st.sidebar.json(edited_json)
-        insert_contract_endpoint(
-            "http://127.0.0.1:8000/insert/contracts", edited_json["物件名"]
-        )
+        if not is_already_exist("contractor", edited_json["物件名"]):
+            st.sidebar.error("エラー: この物件名は既に存在します。")
+        else:
+            st.sidebar.write("以下の内容で保存されました🎉")
+            st.sidebar.json(edited_json)
+            insert_contract_endpoint(
+                "http://127.0.0.1:8000/insert/contracts", edited_json["物件名"]
+            )


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- ダッシュボードへの書き込み時に、同じ内容の行を挿入できる仕様となっている
  - エラーハンドリングとして、同じ値を検知できるようにする

# チケット・参考リンク
- なし

# 変更内容
- getメソッドで、特定行の抽出をできるようにする
  - 特定行をgetすることで、insert時のエラーハンドリングができるようになる
- フロントエンドでエンドポイントにリクエストできるようにする
- file処理部分で、エラーハンドリングを追加する

# 動作確認（確認方法とプロセスを明確に記載する）
- streamlitでの確認
  - cd src streamlit run frontend/app.py
  - ファイルアップによるinsert / 同じ行insert時のエラーハンドリングを確認


# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
