### PR TITLE
Feature/add s3 uploader 20231221

### DIFF
--- a/src/backend/modules/upload_to_s3.py
+++ b/src/backend/modules/upload_to_s3.py
@@ -1,0 +1,48 @@
+from typing import Union
+from PIL import Image
+import io
+import datetime
+from PIL.PpmImagePlugin import PpmImageFile
+
+import boto3
+from streamlit.runtime.uploaded_file_manager import UploadedFile
+
+
+S3_CLIENT = boto3.client("s3")
+DATETIME = datetime.date.today()
+
+
+def upload_streamlit_file_to_s3(
+    streamlit_file: Union[list[PpmImageFile], UploadedFile],
+    bucket_name: str,
+    key: str,
+) -> None:
+    if isinstance(streamlit_file, list):
+        streamlit_file = get_concat_image(streamlit_file)
+
+    S3_CLIENT.put_object(
+        Body=streamlit_file,
+        Bucket=bucket_name,
+        Key=f"{DATETIME}/{key}.jpeg",
+    )
+
+
+def get_concat_image(image_list: list[PpmImageFile]) -> bytes:
+    widths, heights = zip(*(image.size for image in image_list))
+    max_width = max(widths)
+    total_height = sum(heights)
+
+    concat_image = Image.new("RGB", (max_width, total_height))
+
+    y_offset = 0
+    for im in image_list:
+        concat_image.paste(im, (0, y_offset))
+        y_offset += im.size[1]
+
+    return convert_pil_to_bytes(concat_image)
+
+
+def convert_pil_to_bytes(pil_file: Image.Image) -> bytes:
+    img_byte_arr = io.BytesIO()
+    pil_file.save(img_byte_arr, format="JPEG")
+    return img_byte_arr.getvalue()

--- a/src/frontend/component/organisms/file_processor.py
+++ b/src/frontend/component/organisms/file_processor.py
@@ -1,10 +1,11 @@
-from PIL import Image
+from PIL.PpmImagePlugin import PpmImageFile
 from typing import Union
 
 import streamlit as st
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 from backend.main import detect, extract_items
+from backend.modules.upload_to_s3 import upload_streamlit_file_to_s3
 from frontend.component.api.request import insert_contract_endpoint
 from frontend.component.api.request import read_specific_contract_endpoint
 
@@ -16,7 +17,7 @@ def is_already_exist(column_name: str, value: str) -> bool:
     return response is None
 
 
-def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
+def process_file(jpeg_file: Union[UploadedFile, list[PpmImageFile]]) -> None:
     response = detect(jpeg_file)
     contract_items = extract_items(response)
 
@@ -33,6 +34,7 @@ def process_file(jpeg_file: Union[UploadedFile, Image.Image]) -> dict[str, any]:
         else:
             st.sidebar.write("以下の内容で保存されました🎉")
             st.sidebar.json(edited_json)
+            upload_streamlit_file_to_s3(jpeg_file, "contract-ocr", edited_json["物件名"])
             insert_contract_endpoint(
                 "http://127.0.0.1:8000/insert/contracts", edited_json["物件名"]
             )

--- a/tests/backend/models/test_schemas.py
+++ b/tests/backend/models/test_schemas.py
@@ -9,7 +9,7 @@ def test_employee():
         "created_at": "2099-01-01 01:00:00",
     }
 
-    actual = Employee(**employee_data).model_dump()
+    actual = Employee(**employee_data)
     expected = {
         "employee_id": 11111,
         "name": "山田太郎",
@@ -26,7 +26,7 @@ def test_contract():
         "updated_at": "2099-01-01 01:00:00",
     }
 
-    actual = Contract(**contract_data).model_dump()
+    actual = Contract(**contract_data)
     expected = {
         "contract_id": 11111,
         "contractor": "サンプル株式会社",
@@ -45,7 +45,7 @@ def test_employee_event():
         "event_type": "CREATED",
     }
 
-    actual = EmployeeEvent(**event_data).model_dump()
+    actual = EmployeeEvent(**event_data)
     expected = {
         "contract_id": 11111,
         "employee_id": 22222,


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- 契約書の画像をストレージとして保持したい
  - 契約書項目の保存時に、S3にファイルをjpegとして保存できるようにしたい

# チケット・参考リンク
- なし

# 変更内容
- S3へのアップロードメソッドを実装
  - PDFが複数枚ある場合は、連結したjpeg画像にして保存する

# 動作確認（確認方法とプロセスを明確に記載する）
- streamlitでの動作確認
  - PDF(1枚パターン / 複数枚パターン）をアップして、保存時にs3に画像がアップされるか確認
  - `streamlit run frontend/app.py`
- pytestでの確認
  - `cd tests && pytest`

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
